### PR TITLE
Fix: Reset level on game over

### DIFF
--- a/main.py
+++ b/main.py
@@ -610,6 +610,7 @@ def RunGame():
         mixer.music.load(current_music)
         mixer.music.play(-1)
     lines = 0
+    StaticTileindex = 0
     # Variables
     while True:
         rotate = False
@@ -748,6 +749,8 @@ def RunGame():
             if score > highscore:
                 highscore_beaten = True
             gameOver = False
+            # reset static tile index
+            StaticTileindex = 0
             scene = Scene.EndGame
             current_music = None
             return


### PR DESCRIPTION
This pull request fixes the issue where the level was not being reset when the game was over. The level will now reset to 1 when a new game is started.